### PR TITLE
Fix: Compatibility with MacOS Linker

### DIFF
--- a/src/ofxBpm.cpp
+++ b/src/ofxBpm.cpp
@@ -10,6 +10,12 @@
 #include "ofxBpm.h"
 #include "ofMain.h"
 
+//init
+const float ofxBpm::OFX_BPM_MAX = 300. ;
+const float ofxBpm::OFX_BPM_DEFAULT = 120.;
+const float ofxBpm::OFX_BPM_MIN = 1.;
+const int ofxBpm::OFX_BPM_TICK = 960;
+
 ofxBpm::ofxBpm(float bpm,int beatPerBar):_beatPerBar(beatPerBar){
     
     _isPlaying = false;

--- a/src/ofxBpm.cpp
+++ b/src/ofxBpm.cpp
@@ -32,8 +32,8 @@ void ofxBpm::start(){
     _isPlaying = true;
     reset();
     
-    startThread(true, false);   // blocking, verbose
     
+    startThread(true);   // blocking, verbose
 }
 
 void ofxBpm::stop(){

--- a/src/ofxBpm.cpp
+++ b/src/ofxBpm.cpp
@@ -17,136 +17,88 @@ const float ofxBpm::OFX_BPM_MIN = 1.;
 const int ofxBpm::OFX_BPM_TICK = 960;
 
 ofxBpm::ofxBpm(float bpm,int beatPerBar):_beatPerBar(beatPerBar){
-    
     _isPlaying = false;
     _isTick = false;
-    
     setBpm(bpm);
 };
 
 
 void ofxBpm::start(){
-    
     stop();
-    
     _isPlaying = true;
     reset();
-    
-    
     startThread(true);   // blocking, verbose
 }
 
 void ofxBpm::stop(){
-    
     //stopThread();
     waitForThread(true);
-    
     _isPlaying = false;
 }
 
 void ofxBpm::reset(){
-    
-    
-    if( lock() ){
-        
+    if (lock()) {
         _remainderOfTick = 0;
         _countOfTick = -1;
         _preTime = ofGetElapsedTimeMicros();
         _totalTime = 0;
-        
         unlock();
     }
 }
 
-
 void ofxBpm::threadedFunction(){
-    
     //この
     while( isThreadRunning() != 0 ){
-        
         if( lock() ){
-            
-            if(_isPlaying == true){
-                
+            if(_isPlaying == true) {
                 long nowTime = ofGetElapsedTimeMicros();
                 long deltaTime = nowTime - _preTime;
                 _preTime = nowTime;
-                
-                if(_totalTime + _remainderOfTick >= _durationOfTick){
-                    
-                    
-                    if((_countOfTick % (OFX_BPM_TICK / _beatPerBar)) == 0){
-
+                if (_totalTime + _remainderOfTick >= _durationOfTick) {
+                    if ((_countOfTick % (OFX_BPM_TICK / _beatPerBar)) == 0) {
                         ofNotifyEvent(beatEvent);
                     }
-                    
                     _remainderOfTick = (_totalTime + _remainderOfTick) % _durationOfTick;
-                    
                     _totalTime = 0.;
-                    
                     _isTick = true;
-                    
-
-                    
                     _countOfTick++;
                     _countOfTick %= OFX_BPM_TICK;
-
-                    
-                }else{
-                    
+                } else {
                     _isTick = false;
                 }
-                
                 _totalTime += deltaTime;
-                
                 unlock();
-                
                 yield();
             }
         }
     }
-    
 }
 
 void ofxBpm::setBeatPerBar(int beatPerBar){
-    
     if(lock()){
-
         _beatPerBar = beatPerBar;
         unlock();
     }
 }
 
 void ofxBpm::setBpm(float bpm){
-    
     if( lock() ){
-    
-        if(bpm < OFX_BPM_MIN){
-            
+        if (bpm < OFX_BPM_MIN) {
             _bpm = OFX_BPM_MIN;
-            
-        }else if(bpm >= OFX_BPM_MAX){
-            
+        } else if (bpm >= OFX_BPM_MAX){
             _bpm = OFX_BPM_MAX;
-            
-        }else{
-            
+        } else {
             _bpm = bpm;
-            
         }
-        
         _durationOfTick = 60. * 1000. * 1000. / (bpm * (OFX_BPM_TICK >> 2));
-        
         unlock();
     }
 }
 
 float ofxBpm::getBpm() const{
-    
     return _bpm;
 }
 
 bool ofxBpm::isPlaying() const{
-    
     return _isPlaying;
 }

--- a/src/ofxBpm.h
+++ b/src/ofxBpm.h
@@ -8,14 +8,14 @@
 
 /*
 You must add listener on testApp and listen beat timing.
- 
+
 example on testApp.cpp
- 
- 
+
+
 ofAddListener(bpm.beatEvent, this, &testApp::play);
 
 void testApp::play(void){
- 
+
   //sound.play();
   //but, you could not draw somethings.
 }
@@ -27,7 +27,7 @@ void testApp::play(void){
 #include "ofThread.h"
 
 class ofxBpm : private ofThread{
-    
+
 public:
     static const float OFX_BPM_MAX;
     static const float  OFX_BPM_DEFAULT;
@@ -35,25 +35,23 @@ public:
     static const int OFX_BPM_TICK;
 
     explicit ofxBpm(float bpm = OFX_BPM_DEFAULT,int beatPerBar = 4);
-    
+
     void start();
     void stop();
     void reset();
-    
+
     void setBpm(float bpm);
     float getBpm() const;
-    
+
     void setBeatPerBar(int beatPerBar);
-    
+
     bool isPlaying() const;
 
     ofEvent<void> beatEvent;
 
 private:
     void threadedFunction();
-        
-    
-    
+
     float _bpm;
     bool  _isTick;
     bool  _isPlaying;
@@ -61,7 +59,7 @@ private:
     long _totalTime;
     long _durationOfTick;
     long _remainderOfTick;
-    
+
     float _preTime;
     int _beatPerBar;
 

--- a/src/ofxBpm.h
+++ b/src/ofxBpm.h
@@ -64,12 +64,6 @@ private:
     
     float _preTime;
     int _beatPerBar;
-    
+
     inline int getCountOfTick() const;
 };
-
-//init
-const float ofxBpm::OFX_BPM_MAX = 300. ;
-const float ofxBpm::OFX_BPM_DEFAULT = 120.;
-const float ofxBpm::OFX_BPM_MIN = 1.;
-const int ofxBpm::OFX_BPM_TICK = 960;


### PR DESCRIPTION
# Issue
On MacOS with Xcode 15, I'm getting the following error:
```
4 duplicate symbols
Linker command failed with exit code 1 (use -v to see invocation)
```

The reason for this are the constant declarations in the `ofxBpm.h` file

# Solution
Move constant declarations to `ofxBpm.cpp`

I also took liberty to make the change to consumption of `startThread` function to fix this issue: https://github.com/mirrorboy714/ofxBpm/issues/3

Finally, I linted the `ofxBpm.cpp` file